### PR TITLE
fix: point packageRepo at canonical Start9Labs repo

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -15,7 +15,7 @@ export const manifest = setupManifest({
   id: 'robosats',
   title: 'Robosats',
   license: 'AGPL-V3',
-  packageRepo: 'https://github.com/RoboSats/robosats-startos',
+  packageRepo: 'https://github.com/Start9Labs/robosats-startos',
   upstreamRepo: 'https://github.com/Reckless-Satoshi/robosats',
   marketingUrl: 'https://learn.robosats.com/',
   donationUrl: 'https://learn.robosats.com/contribute/donate/',


### PR DESCRIPTION
## Summary

This repo is the canonical Start9Labs home for the `robosats` package on alpha-registry-x, but `packageRepo` still pointed at `RoboSats/robosats-startos`. Aligning with the actual home so the registry reflects ours.

Part of a small fleet-wide sweep — every service on alpha-registry-x.start9.com should have its `packageRepo` pointing at the corresponding `Start9Labs/*` repo (Start9Labs/helix#3 explains why).

## Test plan

- [x] `npm run check` (tsc --noEmit) — clean
- [ ] Republish to alpha-registry-x so the registry's packageRepo for `robosats` reflects the new URL